### PR TITLE
Follow file-like object spec more closely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 **/*.pyc
+splits.egg-info

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='splits',
-    version='0.0.2',
+    version='0.0.3',
     author='Thomas Millar, Jeff Magnusson',
     author_email='millar.thomas@gmail.com, magnussj@gmail.com',
     license='MIT',

--- a/splits/writers.py
+++ b/splits/writers.py
@@ -28,8 +28,11 @@ class SplitWriter(object):
         self.close()
 
     def write(self, data):
-        for line in data.split('\n'):
-            self._write_line(line)
+        for index, line in enumerate(data.split('\n')):
+            if index == data.count('\n'):
+                self._write_line(line)
+            else:
+                self._write_line(line + '\n')
 
     def writelines(self, lines):
         for line in lines:
@@ -37,9 +40,9 @@ class SplitWriter(object):
 
     def _write_line(self, line):
         f = self._get_current_file()
-        f.write(line + '\n')
-        self._linenum += 1
-        self._filelinenum += 1
+        f.write(line)
+        self._linenum += line.count('\n')
+        self._filelinenum += line.count('\n')
 
     def close(self):
         if self._current_file:

--- a/test/test_readers.py
+++ b/test/test_readers.py
@@ -14,7 +14,7 @@ class TestMultiReader(unittest.TestCase):
         os.makedirs(self.path)
 
         self.writer = SplitWriter(self.path, suffix='.txt', lines_per_file=2)
-        self.writer.writelines([str(x) for x in range(0, 10)])
+        self.writer.writelines("\n".join([str(x) for x in range(0, 10)]))
         self.writer.close()
 
         self.reader = SplitReader(self.path + '.manifest')
@@ -27,8 +27,7 @@ class TestMultiReader(unittest.TestCase):
         lines = self.reader.readlines()
 
         self.assertEquals(len(lines), 10)
-        for index, x in enumerate(lines):
-            self.assertEquals(x, str(index))
+        self.assertEquals(''.join(lines), '\n'.join([str(x) for x in range(0, 10)]))
 
     def test_read(self):
         lines = self.reader.read()
@@ -36,3 +35,22 @@ class TestMultiReader(unittest.TestCase):
         self.assertEquals(len(lines.split('\n')), 10)
         for index, x in enumerate(lines.split('\n')):
             self.assertEquals(x, str(index))
+
+    def test_read_n_chars(self):
+        for index, x in enumerate(range(0, 19)):
+            char = self.reader.read(1)
+            if index % 2 == 0:
+                self.assertEquals(char, str(x/2))
+            else:
+                self.assertEquals(char, '\n')
+
+        self.assertEquals(self.reader.read(1), '')
+
+    def test_read_line_n_chars(self):
+        line = self.reader.readline(1)
+        self.assertEquals('0', line)
+        line = self.reader.readline()
+        self.assertEquals('\n', line)
+        line = self.reader.readline()
+        self.assertEquals('1\n', line)
+

--- a/test/test_writers.py
+++ b/test/test_writers.py
@@ -32,7 +32,7 @@ class TestMultiWriter(unittest.TestCase):
         self.assertFalse(self.fileExists('%06d.txt' % 6))
 
     def test_writes_correct_number_of_files_with_writelines(self):
-        self.writer.writelines([str(x) for x in range(0, 10)])
+        self.writer.writelines('\n'.join([str(x) for x in range(0, 10)]))
 
         for i in range(1, 6):
             self.assertTrue(self.fileExists('%06d.txt' % i))
@@ -40,7 +40,7 @@ class TestMultiWriter(unittest.TestCase):
         self.assertFalse(self.fileExists('%06d.txt' % 6))
 
     def test_writes_odd_number_of_lines(self):
-        self.writer.writelines([str(x) for x in range(0, 11)])
+        self.writer.writelines('\n'.join([str(x) for x in range(0, 11)]))
 
         for i in range(1, 7):
             self.assertTrue(self.fileExists('%06d.txt' % i))


### PR DESCRIPTION
This commit fixes the writer and the reader to not callously remove
newline characters. It now behaves more like a proper file-like object.
Furthermore, this commit fixes the reader to handle the optional
parameters on read() and readline().
## Newlines

The example below shows how the write and read function should work. This commit makes SplitWriter behave as below.

``` python

with open('/tmp/test.txt', 'w') as w:
    w.writelines(['foo', 'bar'])
    w.writelines(['baz\n', 'baa'])

print open('/tmp/test.txt', 'r').read()
# => 'foobarbaz\nbaa'
```
## Reading N Chars

This commit abides the `read()` and `readline()` spec by allow us to read variable number of chars. Also this commit makes sure that we don't return `StopIteration()` but rather an empty string, as per the spec.
