### PR TITLE
Fix silent data corruption bug issue #13 by re-raising exceptions

### DIFF
--- a/splits/readers.py
+++ b/splits/readers.py
@@ -57,8 +57,10 @@ class SplitReader(object):
 
                 if num > 0 and len(val) == num:
                     break
-        except:
+        except StopIteration:
             pass
+        except Exception as e:
+            raise Exception("Unhandled exception in SplitReader:"+repr(e))
 
         return val
 
@@ -81,8 +83,10 @@ class SplitReader(object):
                     break
                 elif line.endswith('\n'):
                     break
-        except:
+        except StopIteration:
             pass
+        except Exception as e:
+            raise Exception("Unhandled exception in SplitReader:"+repr(e))
 
         return line
 

--- a/splits/readers.py
+++ b/splits/readers.py
@@ -59,8 +59,6 @@ class SplitReader(object):
                     break
         except StopIteration:
             pass
-        except Exception as e:
-            raise Exception("Unhandled exception in SplitReader:"+repr(e))
 
         return val
 
@@ -85,8 +83,6 @@ class SplitReader(object):
                     break
         except StopIteration:
             pass
-        except Exception as e:
-            raise Exception("Unhandled exception in SplitReader:"+repr(e))
 
         return line
 


### PR DESCRIPTION
Re-raise most exceptions in SplitReader.read and readline.