### PR TITLE
Use single Provider in S3 object to avoid NoAuthHandler exceptions

### DIFF
--- a/splits/s3.py
+++ b/splits/s3.py
@@ -2,9 +2,11 @@ import StringIO
 import gzip
 import boto.s3
 import boto.s3.connection
+import boto.provider
 import urlparse
 import zipfile
 from itertools import groupby
+
 
 def is_s3_uri(uri):
     uri = str(uri)
@@ -49,7 +51,7 @@ class S3(object):
         # use a single provider to avoid NoAuthHandler exceptions
         # see: http://blog.johnryding.com/post/122337566993/solving-intermittent-noauthhandlerfound-errors-in
         if S3.aws_settings_provider is None:
-            S3.aws_settings_provider = Provider('aws')
+            S3.aws_settings_provider = boto.provider.Provider('aws')
 
         self._conn = boto.s3.connect_to_region(
             region,

--- a/splits/s3.py
+++ b/splits/s3.py
@@ -42,14 +42,20 @@ class S3Uri(object):
     def __str__(self):
         return self.name
 
-
 class S3(object):
+    aws_settings_provider = None
 
     def __init__(self, region='us-east-1'):
+        # use a single provider to avoid NoAuthHandler exceptions
+        # see: http://blog.johnryding.com/post/122337566993/solving-intermittent-noauthhandlerfound-errors-in
+        if S3.aws_settings_provider is None:
+            S3.aws_settings_provider = Provider('aws')
+
         self._conn = boto.s3.connect_to_region(
             region,
-            calling_format=boto.s3.connection.OrdinaryCallingFormat()
-    )
+            calling_format=boto.s3.connection.OrdinaryCallingFormat(),
+            provider=S3.aws_settings_provider
+        )
 
     @property
     def access_key(self):


### PR DESCRIPTION
This PR follows the advice in http://blog.johnryding.com/post/122337566993/solving-intermittent-noauthhandlerfound-errors-in and uses a single Provider image. In my tests this eliminated the NoAuthHandler exceptions that led to the problem in issue 13.

This may not be the best way to solve the issue, but I'm submitting the PR for discussion. Another approach would be to increase the timeout and number of retries for boto metadata lookups:

http://boto.readthedocs.org/en/latest/boto_config_tut.html?highlight=retries#boto
Look for configuration options
metadata_service_timeout
metadata_service_num_attempts
