### PR TITLE
Finalize Python 2/3 issues before migration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md') as readme_file:
 
 setup(
     name='splits',
-    version='0.1.7',
+    version='0.1.8',
     author='Thomas Millar, Jeff Magnusson',
     author_email='millar.thomas@gmail.com, magnussj@gmail.com',
     license='MIT',

--- a/splits/readers.py
+++ b/splits/readers.py
@@ -4,7 +4,7 @@ class SplitReader(object):
     def __init__(self,
                  manifest_path_or_list,
                  fileClass=open,
-                 fileArgs={'mode': 'r'}):
+                 fileArgs={'mode': 'rb'}):
         self.fileClass = fileClass
         self.fileArgs = fileArgs
 
@@ -43,7 +43,7 @@ class SplitReader(object):
         pass
 
     def read(self, num=None):
-        val = ''
+        val = b''
 
         if num is None:
             num = 0
@@ -58,8 +58,6 @@ class SplitReader(object):
                 if not new_data:
                     self._current_file.close()
                 else:
-                    if isinstance(new_data, bytes):
-                        new_data = new_data.decode('utf-8')
                     val += new_data
 
                 if num > 0 and len(val) == num:
@@ -70,7 +68,7 @@ class SplitReader(object):
         return val
 
     def readline(self, limit=None):
-        line = ''
+        line = b''
 
         if limit is None:
             limit = 0
@@ -86,13 +84,11 @@ class SplitReader(object):
                 if not new_data:
                     self._current_file.close()
                 else:
-                    if isinstance(new_data, bytes):
-                        new_data = new_data.decode('utf-8')
                     line += new_data
 
                 if limit > 0 and len(line) == limit:
                     break
-                elif line.endswith('\n'):
+                elif line.endswith(b'\n'):
                     break
         except StopIteration:
             pass

--- a/splits/s3.py
+++ b/splits/s3.py
@@ -140,7 +140,7 @@ class S3File(six.BytesIO, object):
             self.__init_s3()
         six.BytesIO.__init__(self)
 
-        if self.mode == 'r':
+        if 'r' in self.mode:
             self.s3.getfile(self.s3uri, self)
             self.seek(0)
 
@@ -161,13 +161,13 @@ class S3File(six.BytesIO, object):
             super(S3File, self).write(data)
 
     def close(self):
-        if self.mode == 'w':
+        if 'w' in self.mode:
             self.flush()
             self.s3.putfile(self, self.s3uri)
 
 class GzipS3File(gzip.GzipFile):
     def __init__(self, uri, *args, **kwargs):
-        mode = kwargs['mode'] if 'mode' in kwargs else 'r'
+        mode = kwargs['mode'] if 'mode' in kwargs else 'rb'
         s3 = kwargs['s3'] if 's3' in kwargs else None
         self.s3File = S3File(uri, mode=mode, s3=s3)
         super(GzipS3File, self).__init__(fileobj=self.s3File, mode=mode)

--- a/test/context.py
+++ b/test/context.py
@@ -1,0 +1,7 @@
+# See http://docs.python-guide.org/en/latest/writing/structure/
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+
+from splits.readers import SplitReader
+from splits.writers import SplitWriter

--- a/test/test_writers.py
+++ b/test/test_writers.py
@@ -3,7 +3,12 @@ import tempfile
 import shutil
 import os
 
-from splits import SplitWriter
+from context import SplitWriter
+
+
+def stringify(intval, skip_nl):
+    newline = '\n' if not skip_nl else ''
+    return (str(intval) + newline).encode("utf-8")
 
 
 class TestMultiWriter(unittest.TestCase):
@@ -24,7 +29,7 @@ class TestMultiWriter(unittest.TestCase):
         return os.path.isfile(path)
 
     def test_writes_correct_number_of_files(self):
-        self.writer.write('\n'.join([str(x) for x in range(0, 10)]))
+        self.writer.write(b'\n'.join([stringify(x, True) for x in range(0, 10)]))
 
         for i in range(1, 6):
             self.assertTrue(self.fileExists('%06d.txt' % i))
@@ -32,7 +37,7 @@ class TestMultiWriter(unittest.TestCase):
         self.assertFalse(self.fileExists('%06d.txt' % 6))
 
     def test_writes_correct_number_of_files_with_writelines(self):
-        self.writer.writelines('\n'.join([str(x) for x in range(0, 10)]))
+        self.writer.writelines([stringify(x, x == 9) for x in range(0, 10)])
 
         for i in range(1, 6):
             self.assertTrue(self.fileExists('%06d.txt' % i))
@@ -40,7 +45,7 @@ class TestMultiWriter(unittest.TestCase):
         self.assertFalse(self.fileExists('%06d.txt' % 6))
 
     def test_writes_odd_number_of_lines(self):
-        self.writer.writelines('\n'.join([str(x) for x in range(0, 11)]))
+        self.writer.writelines([stringify(x, x == 10) for x in range(0, 11)])
 
         for i in range(1, 7):
             self.assertTrue(self.fileExists('%06d.txt' % i))


### PR DESCRIPTION
In order to get things fully working across the variety
of functions where we use this, I had to make a few changes
that included backing out some recent changes while adding
others (so it wasn't a matter of just rolling back).

TL;DR version:  the reader is always in binary mode, while the
writer operates also in binary mode but will encode strings if
needed.  This makes things work consistently and fixes issues
#22  and #23 .

Changes:
* Removed decode calls from the reader
* Structure everything so that it handles bytes (so string
literals are encoded as bytes like: `b'\n'`)
* Fix unit tests to do the same
* A few other python 3 fixes
* Unit test that made call to writelines was not correct, should
pass in a list of lines with newlines at the end

With these changes, unit tests work (running tox) and various functions
in Ripley seem to work.