### PR TITLE
Test before encoding should check if not bytes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md') as readme_file:
 
 setup(
     name='splits',
-    version='0.1.8',
+    version='0.1.9',
     author='Thomas Millar, Jeff Magnusson',
     author_email='millar.thomas@gmail.com, magnussj@gmail.com',
     license='MIT',

--- a/splits/writers.py
+++ b/splits/writers.py
@@ -1,5 +1,4 @@
 import os
-import six
 
 from splits.util import path_for_part
 
@@ -28,7 +27,7 @@ class SplitWriter(object):
         self.close()
 
     def write(self, data):
-        if isinstance(data, six.string_types):
+        if not isinstance(data, bytes):
             data = data.encode('utf-8')
         cnt = data.count(b'\n')
         for index, line in enumerate(data.split(b'\n')):
@@ -39,7 +38,7 @@ class SplitWriter(object):
 
     def writelines(self, lines):
         for line in lines:
-            if isinstance(line, six.string_types):
+            if not isinstance(line, bytes):
                 line = line.encode('utf-8')
             self._write_line(line)
 

--- a/test/test_writers.py
+++ b/test/test_writers.py
@@ -36,6 +36,14 @@ class TestMultiWriter(unittest.TestCase):
 
         self.assertFalse(self.fileExists('%06d.txt' % 6))
 
+    def test_writes_correct_number_of_files_str(self):
+        self.writer.write('\n'.join(["ln{}".format(x) for x in range(0, 10)]))
+
+        for i in range(1, 6):
+            self.assertTrue(self.fileExists('%06d.txt' % i))
+
+        self.assertFalse(self.fileExists('%06d.txt' % 6))
+
     def test_writes_correct_number_of_files_with_writelines(self):
         self.writer.writelines([stringify(x, x == 9) for x in range(0, 10)])
 
@@ -51,3 +59,7 @@ class TestMultiWriter(unittest.TestCase):
             self.assertTrue(self.fileExists('%06d.txt' % i))
 
         self.assertFalse(self.fileExists('%06d.txt' % 7))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Using `six.string_types` as the criteria in python 2 doesn't work.
This because if it's a unicode string already encoded into bytes,
it's type in Python 2 is 'str', making the test true and we encode
again, getting an error.

Note: this is one last changed found while testing box report uploads and some legacy flows.